### PR TITLE
#S3.1.2 - Mobile: Registered User Dashboard

### DIFF
--- a/mobileapp/app/src/main/AndroidManifest.xml
+++ b/mobileapp/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Mobileapp">
         <activity
-            android:name=".ui.MainActivity"
+            android:name=".ui.UserMainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -22,6 +22,10 @@
         </activity>
         <activity
             android:name=".ui.AuthActivity"
+            android:exported="false">
+        </activity>
+        <activity
+            android:name=".ui.MainActivity"
             android:exported="false">
         </activity>
     </application>

--- a/mobileapp/app/src/main/java/com/example/mobileapp/ui/UserDashboardFragment.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/ui/UserDashboardFragment.java
@@ -1,0 +1,40 @@
+package com.example.mobileapp.ui;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
+import androidx.drawerlayout.widget.DrawerLayout;
+import androidx.fragment.app.Fragment;
+import com.example.mobileapp.R;
+import com.google.android.material.navigation.NavigationView;
+
+public class UserDashboardFragment extends Fragment {
+
+    private Toolbar toolbar;
+    private DrawerLayout drawerLayout;
+    private NavigationView navView;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_user_dashboard, container, false);
+
+        setupMapChild();
+
+        return view;
+    }
+
+
+    private void setupMapChild() {
+        if (getChildFragmentManager().findFragmentById(R.id.mapContainer) == null) {
+            getChildFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.mapContainer, new MapFragment())
+                    .commit();
+        }
+    }
+}

--- a/mobileapp/app/src/main/java/com/example/mobileapp/ui/UserMainActivity.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/ui/UserMainActivity.java
@@ -1,0 +1,131 @@
+package com.example.mobileapp.ui;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.ImageButton;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.view.GravityCompat;
+import androidx.drawerlayout.widget.DrawerLayout;
+
+import com.example.mobileapp.R;
+import com.google.android.material.navigation.NavigationView;
+
+public class UserMainActivity extends AppCompatActivity
+        implements NavigationView.OnNavigationItemSelectedListener {
+
+    // Root DrawerLayout (contains main content + navigation drawer)
+    private DrawerLayout drawerLayout;
+
+    // NavigationView that shows the menu items inside the drawer
+    private NavigationView navigationView;
+
+    // Buttons from the custom header inside the Toolbar
+    private ImageButton btnMenu;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.activity_user_main);
+
+        // Root view is the DrawerLayout with id "main"
+        drawerLayout = findViewById(R.id.main);
+        navigationView = findViewById(R.id.nav_view);
+        navigationView.setNavigationItemSelectedListener(this);
+
+        // Get header view from NavigationView
+        View headerView = navigationView.getHeaderView(0);
+
+        // Find close button inside header layout
+        View closeDrawerBtn = headerView.findViewById(R.id.close_drawer_btn);
+
+        // Set click listener to close the drawer
+        closeDrawerBtn.setOnClickListener(v ->
+                drawerLayout.closeDrawer(GravityCompat.START)
+        );
+
+        // Toolbar that holds the custom header (toolbar_header)
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+
+        // Get hamburger and profile buttons from toolbar_header
+        btnMenu = toolbar.findViewById(R.id.btn_menu);
+
+        // Open the navigation drawer when the hamburger button is clicked
+        btnMenu.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                drawerLayout.openDrawer(GravityCompat.START);
+            }
+        });
+
+        // Listen for navigation item clicks from the drawer menu
+        navigationView.setNavigationItemSelectedListener(this);
+
+        // Initial fragment when opening MainActivity
+        if (savedInstanceState == null) {
+            getSupportFragmentManager().beginTransaction()
+                    .replace(R.id.fragment_container, new UserDashboardFragment())
+                    .commit();
+
+            // Mark ride history as selected in the drawer
+            navigationView.setCheckedItem(R.id.nav_dashboard);
+        }
+    }
+
+    @Override
+    public boolean onNavigationItemSelected(@NonNull MenuItem item) {
+        // Handle clicks on drawer menu items
+        int id = item.getItemId();
+
+        if (id == R.id.nav_dashboard) {
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.fragment_container, new UserDashboardFragment())
+                    .addToBackStack(null)
+                    .commit();
+
+
+        } else if (id == R.id.nav_ride_history) {
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.fragment_container, new RideHistoryFragment())
+                    .addToBackStack(null)
+                    .commit();
+
+        } else if (id == R.id.nav_booked_rides) {
+            // TODO: open BookedRidesFragment
+
+        } else if (id == R.id.nav_book_ride) {
+            // TODO: open BookARideFragment
+
+        } else if (id == R.id.nav_reports) {
+            // TODO: open ReportsFragment
+
+        } else if (id == R.id.nav_support) {
+            // TODO: open SupportFragment
+
+        } else if (id == R.id.nav_profile) {
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.fragment_container, new ProfileFragment())
+                    .addToBackStack(null)
+                    .commit();
+
+        } else if (id == R.id.nav_sign_out) {
+            Intent intent = new Intent(UserMainActivity.this, AuthActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+            startActivity(intent);
+            finish();
+        }
+
+        // Always close the drawer after handling a click
+        drawerLayout.closeDrawer(GravityCompat.START);
+        return true;
+    }
+}

--- a/mobileapp/app/src/main/res/layout/activity_user_main.xml
+++ b/mobileapp/app/src/main/res/layout/activity_user_main.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context=".ui.UserMainActivity">
+
+    <!-- Main screen content (toolbar + fragment area) -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <!-- App Toolbar with custom header inside -->
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:background="@color/dark_grey"
+            android:elevation="2dp">
+
+            <!-- custom header with hamburger, logo, profile button -->
+            <include layout="@layout/toolbar_header" />
+        </androidx.appcompat.widget.Toolbar>
+
+        <!-- Fragment container: here we show RideHistory, Profile, etc. -->
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fragment_container"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            tools:layout="@layout/fragment_user_dashboard"/>
+    </LinearLayout>
+
+    <!-- Navigation drawer on the left side -->
+    <com.google.android.material.navigation.NavigationView
+        android:id="@+id/nav_view"
+        android:fitsSystemWindows="true"
+        android:layout_width="300dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:background="@color/app_dark"
+        app:headerLayout="@layout/drawer_header"
+        style="@style/AppNavigationViewStyle"
+        android:paddingStart="15dp"
+        android:paddingEnd="15dp"
+        app:menu="@menu/menu_passenger" />   <!-- for now use driver menu only -->
+
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/mobileapp/app/src/main/res/layout/fragment_user_dashboard.xml
+++ b/mobileapp/app/src/main/res/layout/fragment_user_dashboard.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+    <!-- Map Container -->
+    <FrameLayout
+        android:id="@+id/mapContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+    </FrameLayout>
+
+</LinearLayout>


### PR DESCRIPTION
### Description

Implemented the registered user mobile dashboard for the Android app using the existing Leaflet `MapFragment `and the role-based navigation drawer.


### Features Implemented

* Connected the authenticated user MainActivity with a role-aware navigation drawer (driver/passenger) and a map-centered dashboard.
* Introduced a `DashboardFragment `that renders a logged-in header (toolbar with hamburger in the top-left) and embeds the existing WebView-based `MapFragment `below it.
* Keeps the existing toolbar header with a custom hamburger button wired to open/close the drawer.

#### DashboardFragment

* New fragment that acts as the logged-in user dashboard container.
* Displays the top header (toolbar) and loads the existing `MapFragment `into a dedicated `mapContainer `via `getChildFragmentManager()`.
* Hooks the toolbar navigation icon to the DrawerLayout from MainActivity to open the sidebar.

#### UI & Layout

* Consistent spacing, typography, and rounded components based on the design system tokens.

### Issue

Closes #44 
