### PR TITLE
#S3.2.6.3 - Fix: Panic Button

### DIFF
--- a/webapp/src/app/core/services/notification.service.ts
+++ b/webapp/src/app/core/services/notification.service.ts
@@ -22,9 +22,7 @@ constructor(
   }
   notifyAdminAboutPanic(rideId: number, userId: number | null) : void {
     this.http.post(this.configService.ridesUrl + `/${rideId}/panic`, { userId }).subscribe({
-      next: () => {
-        console.log('Admin notified about panic');
-      },
+      next: () => {},
       error: (err) => {
         console.error('Failed to notify admin about panic', err);
       }

--- a/webapp/src/app/features/driver/pages/dashboard/driver-dashboard/driver-dashboard.ts
+++ b/webapp/src/app/features/driver/pages/dashboard/driver-dashboard/driver-dashboard.ts
@@ -23,6 +23,7 @@ import { ActiveRideSimRunnerService } from '../../../../shared/services/active-r
 import { VehicleMarker } from '../../../../shared/map/vehicle-marker';
 import { LatLng } from '../../../../shared/services/routing.service';
 import { Subscription } from 'rxjs';
+import { NotificationService } from '../../../../../core/services/notification.service';
 
 type Passenger = { name: string; email: string };
 
@@ -54,6 +55,7 @@ export class DriverDashboard implements OnDestroy {
   ridesService = inject(DriverRidesService);
   userService = inject(UserService);
   rideState = inject(CurrentRideStateService);
+  notificationService = inject(NotificationService);
 
   private follow = inject(VehicleFollowService);
   private simRunner = inject(ActiveRideSimRunnerService);
@@ -95,6 +97,7 @@ export class DriverDashboard implements OnDestroy {
         })),
         { lat: r.endLocation.latitude, lon: r.endLocation.longitude, label: 'Destination' },
       ];
+      this.rideState.loadPanic(r.id);
 
       // follow per driverEmail
       if (r.driverEmail && r.driverEmail !== this.driverEmail) {
@@ -130,7 +133,6 @@ export class DriverDashboard implements OnDestroy {
     });
 
     this.userService.fetchMe().subscribe();
-    this.rideState.loadPanic();
 
     this.subs.push(
       this.simRunner.onSimulationComplete$.subscribe(rideId => {
@@ -241,6 +243,7 @@ export class DriverDashboard implements OnDestroy {
         this.ridesService.fetchRides().subscribe();
         this.simRunner.stopForRide(r.id);
         this.simulationCompleted.set(false);
+        this.rideState.clearPanic(r.id);
       },
       error: (err) => console.error('Failed to complete ride', err)
     });

--- a/webapp/src/app/features/registered/pages/current-ride/current-ride.ts
+++ b/webapp/src/app/features/registered/pages/current-ride/current-ride.ts
@@ -14,6 +14,7 @@ import { LocationDTO } from '../../../shared/models/location';
 
 import { Subscription } from 'rxjs';
 import { VehicleFollowService } from '../../../shared/services/vehicle-follow.service';
+import { NotificationService } from '../../../../core/services/notification.service';
 
 type UiRideStatus = 'Assigned' | 'Started' | 'Finished' | 'Cancelled';
 type PassengerItem = { id: number; name: string; email: string; role: 'You' | 'Passenger' };
@@ -29,6 +30,7 @@ export class CurrentRideComponent implements OnInit, OnDestroy {
   private userService = inject(UserService);
   private rideService = inject(RideService);
   public rideState = inject(CurrentRideStateService);
+  private notificationService = inject(NotificationService);
 
   private follow = inject(VehicleFollowService);
   private subs: Subscription[] = [];
@@ -88,7 +90,7 @@ export class CurrentRideComponent implements OnInit, OnDestroy {
           email: p.email,
           role: 'Passenger' as const,
         }));
-
+        this.rideState.loadPanic(r.id);
         // FOLLOW (per driver)
         if (r.driverEmail) {
           this.driverEmail = r.driverEmail;

--- a/webapp/src/app/features/registered/services/current-ride-state.service.ts
+++ b/webapp/src/app/features/registered/services/current-ride-state.service.ts
@@ -7,15 +7,27 @@ export class CurrentRideStateService {
   panicSignal = signal<{pressed: boolean; rideId: number; userId: number}>({pressed: false, rideId: 0, userId: 0})
 
   setPanic(rideId: number, userId: number) {
-    const state = {pressed: true, rideId, userId};
-    this.panicSignal.set(state);
-    localStorage.setItem('panic_currentRide', JSON.stringify(state));
+    const fullState = { pressed: true, rideId, userId};
+    localStorage.setItem(this.getStorageKey(rideId), JSON.stringify(fullState));
+    this.panicSignal.set(fullState);
   }
 
-  loadPanic() {
-    const saved = localStorage.getItem('panic_currentRide');
-    if (saved) {
-      this.panicSignal.set(JSON.parse(saved));
+  loadPanic(rideId: number): void {
+    const saved = localStorage.getItem(this.getStorageKey(rideId));
+    if (!saved) return;
+    
+    try {
+      const state = JSON.parse(saved);
+      this.panicSignal.set(state);
+    } catch (e) {
+      console.error('Corrupted panic storage');
     }
+  }
+  private getStorageKey(rideId: number): string {
+    return `panic_${rideId}`;
+  }
+  clearPanic(rideId: number): void {
+    localStorage.removeItem(this.getStorageKey(rideId));
+    this.panicSignal.set({pressed: false, rideId: 0, userId: 0});
   }
 }


### PR DESCRIPTION
Updated panic state handling to use ride-specific storage keys, allowing multiple rides to manage panic state independently. Added methods to load and clear panic state per ride, and updated components to use these methods. Removed unnecessary console logs and improved error handling for corrupted storage.