### PR TITLE
#S3.2.6.3 - Mobile: Panic Button

### DIFF
--- a/mobileapp/app/build.gradle.kts
+++ b/mobileapp/app/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(libs.cardview)
     implementation(libs.glide)
     implementation(libs.google.material)
+    implementation(libs.swiperefreshlayout)
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)

--- a/mobileapp/app/src/main/java/com/example/mobileapp/AdminMainActivity.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/AdminMainActivity.java
@@ -15,6 +15,7 @@ import androidx.drawerlayout.widget.DrawerLayout;
 import com.bumptech.glide.Glide;
 import com.example.mobileapp.features.admin.driverMonitoring.AdminDriverMonitorFragment;
 import com.example.mobileapp.features.admin.driverRegistration.DriverRegisterFragment;
+import com.example.mobileapp.features.admin.panicNotifications.AdminPanicsFragment;
 import com.example.mobileapp.features.admin.pricingManagement.PricingManagementFragment;
 import com.example.mobileapp.features.admin.profileChanges.ProfileChangesFragment;
 import com.example.mobileapp.features.passenger.dashboard.UserDashboardFragment;
@@ -149,7 +150,11 @@ public class AdminMainActivity extends AppCompatActivity
                     .commit();
 
         } else if (id == R.id.nav_panic_notifications) {
-            // TODO: open ReportsFragment
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.fragment_container, new AdminPanicsFragment())
+                    .addToBackStack(null)
+                    .commit();
 
         } else if (id == R.id.nav_profile) {
             getSupportFragmentManager()

--- a/mobileapp/app/src/main/java/com/example/mobileapp/core/api/AuthApi.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/core/api/AuthApi.java
@@ -10,6 +10,7 @@ import retrofit2.http.Body;
 import retrofit2.http.Multipart;
 import retrofit2.http.POST;
 import retrofit2.http.Part;
+import retrofit2.http.Query;
 
 public interface AuthApi {
 
@@ -20,4 +21,9 @@ public interface AuthApi {
     @POST("api/auth/register")
     Call<Void> register(@Part("user") RegisterRequest user,
                         @Part MultipartBody.Part profileImage);
+
+    @POST("api/auth/activate")
+    Call<LoginResponse> activate(
+            @Query("token") String activationToken
+    );
 }

--- a/mobileapp/app/src/main/java/com/example/mobileapp/core/auth/LoginFragment.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/core/auth/LoginFragment.java
@@ -135,7 +135,7 @@ public class LoginFragment extends Fragment {
                         showError("Please verify your email first");
                         return;
                     }
-
+                    prefs.edit().putInt("userId",meResponse.body().getId()).apply();
                     UserRepository.getInstance().setCurrentUser(user);
 
                     if (user.getRole() == UserRole.DRIVER) {

--- a/mobileapp/app/src/main/java/com/example/mobileapp/core/network/ApiClient.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/core/network/ApiClient.java
@@ -16,8 +16,8 @@ import retrofit2.converter.gson.GsonConverterFactory;
 
 public final class ApiClient {
 
-    private static final String BASE_URL = "http://192.168.0.18:8080/";
-//     private static final String BASE_URL = "http://10.0.2.2:8080/";
+    //private static final String BASE_URL = "http://192.168.0.10:8080/";
+    private static final String BASE_URL = "http://10.0.2.2:8080/";
 
     private static final String OSRM_BASE_URL = "https://router.project-osrm.org/";
 

--- a/mobileapp/app/src/main/java/com/example/mobileapp/features/admin/panicNotifications/AdminPanicAdapter.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/features/admin/panicNotifications/AdminPanicAdapter.java
@@ -1,0 +1,128 @@
+package com.example.mobileapp.features.admin.panicNotifications;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.mobileapp.R;
+import com.example.mobileapp.features.shared.api.dto.PanicNotificationDto;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class AdminPanicAdapter extends RecyclerView.Adapter<AdminPanicAdapter.PanicViewHolder> {
+    private final List<PanicNotificationDto> panics = new ArrayList<>();
+    private Context context;
+    private OnResolveClickListener resolveClickListener;
+    public interface OnResolveClickListener {
+        void onResolveClick(PanicNotificationDto panic);
+    }
+
+    public void setOnResolveClickListener(OnResolveClickListener listener) {
+        this.resolveClickListener = listener;
+    }
+    public void setPanics(List<PanicNotificationDto> newPanics) {
+        this.panics.clear();
+        if (newPanics != null) this.panics.addAll(newPanics);
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public PanicViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        context = parent.getContext();
+        View view = LayoutInflater.from(context)
+                .inflate(R.layout.item_admin_panic, parent, false);
+        return new PanicViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull PanicViewHolder holder, int position) {
+        PanicNotificationDto panic = panics.get(position);
+
+        holder.tvRideNumber.setText("Ride #" + panic.getRideId());
+        holder.tvUserEmail.setText(panic.getActivatedBy());
+        holder.tvTypeLabel.setText("Type: ");
+        holder.tvType.setText(panic.getUserType().toString());
+        holder.tvTime.setText(formatTimestamp(panic.getTimestamp()));
+        holder.btnResolve.setOnClickListener(v -> {
+            if (resolveClickListener != null) {
+                resolvePanic(holder, panic, position);
+            }
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        return panics.size();
+    }
+
+    private void resolvePanic(PanicViewHolder holder, PanicNotificationDto panic, int position) {
+        new androidx.appcompat.app.AlertDialog.Builder(context)
+                .setTitle("Resolve Panic")
+                .setMessage("Resolve panic for Ride #" + panic.getRideId() + "?")
+                .setPositiveButton("Resolve", (dialog, which) -> {
+                    if (resolveClickListener != null) {
+                        resolveClickListener.onResolveClick(panic);
+                    }
+                    Toast.makeText(context, "Panic resolved", Toast.LENGTH_SHORT).show();
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private String formatTimestamp(Object timestamp) {
+        if (timestamp == null) return "Time Error";
+
+        try {
+            if (timestamp instanceof LocalDateTime) {
+                return DateTimeFormatter.ofPattern("M/dd/yy, h:mm a", Locale.getDefault())
+                        .format((LocalDateTime) timestamp);
+            } else {
+                String s = timestamp.toString();
+                int dot = s.indexOf('.');
+                if (dot != -1) s = s.substring(0, dot);
+                String[] parts = s.split("T");
+                if (parts.length == 2) {
+                    String[] ymd = parts[0].split("-");
+                    String[] hms = parts[1].split(":");
+                    if (ymd.length == 3 && hms.length >= 2) {
+                        return String.format(Locale.US, "%s/%s/%s, %s:%s %s",
+                                ymd[1], ymd[2], ymd[0].substring(2),
+                                hms[0], hms[1], hms[0].compareTo("12") >= 0 ? "PM" : "AM");
+                    }
+                }
+            }
+        } catch (Exception ignored) {}
+        return "Time Error";
+    }
+
+    static class PanicViewHolder extends RecyclerView.ViewHolder {
+        TextView tvRideNumber, tvUserEmail, tvTypeLabel, tvType, tvTime, tvActive;
+        Button btnResolve;
+        ImageView ivAlertIcon;
+
+        PanicViewHolder(@NonNull View itemView) {
+            super(itemView);
+            tvRideNumber = itemView.findViewById(R.id.tvRideNumber);
+            tvUserEmail = itemView.findViewById(R.id.tvUserEmail);
+            tvTypeLabel = itemView.findViewById(R.id.tvTypeLabel);
+            tvType = itemView.findViewById(R.id.tvType);
+            tvTime = itemView.findViewById(R.id.tvTime);
+            tvActive = itemView.findViewById(R.id.tvActive);
+            btnResolve = itemView.findViewById(R.id.btnResolve);
+            ivAlertIcon = itemView.findViewById(R.id.ivAlertIcon);
+        }
+    }
+}

--- a/mobileapp/app/src/main/java/com/example/mobileapp/features/admin/panicNotifications/AdminPanicsFragment.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/features/admin/panicNotifications/AdminPanicsFragment.java
@@ -1,0 +1,87 @@
+package com.example.mobileapp.features.admin.panicNotifications;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.mobileapp.R;
+import com.example.mobileapp.features.admin.services.AdminPanicService;
+import com.example.mobileapp.features.shared.api.dto.PanicNotificationDto;
+
+import java.util.List;
+
+public class AdminPanicsFragment extends Fragment {
+
+    private TextView tvActiveCount, tvAlertCount;
+    private RecyclerView rvPanicAlerts;
+    private LinearLayout layoutEmptyState;
+    private AdminPanicAdapter adapter;
+    private AdminPanicService service;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_admin_panics, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        bindViews(view);
+        setupRecyclerView();
+        setupService();
+        fetchPanics();
+    }
+
+    private void bindViews(View view) {
+        tvActiveCount = view.findViewById(R.id.tvActiveCount);
+        tvAlertCount = view.findViewById(R.id.tvAlertCount);
+        rvPanicAlerts = view.findViewById(R.id.rvPanicAlerts);
+        layoutEmptyState = view.findViewById(R.id.layoutEmptyState);
+    }
+
+    private void setupRecyclerView() {
+        adapter = new AdminPanicAdapter();
+        rvPanicAlerts.setLayoutManager(new LinearLayoutManager(requireContext()));
+        rvPanicAlerts.setAdapter(adapter);
+        adapter.setOnResolveClickListener(panic -> {
+            service.resolvePanic(panic.getRideId());
+        });
+    }
+
+    private void setupService() {
+        service = new AdminPanicService(requireContext());
+        service.panics().observe(getViewLifecycleOwner(), this::onPanicsUpdated);
+    }
+
+    public void fetchPanics() {
+        service.fetchPanics();
+    }
+
+    private void onPanicsUpdated(List<PanicNotificationDto> panics) {
+        adapter.setPanics(panics);
+        updateHeaderCounts(panics);
+    }
+
+    private void updateHeaderCounts(List<PanicNotificationDto> panics) {
+        int activeCount = panics.size();
+        tvActiveCount.setText(activeCount + " active");
+        tvAlertCount.setText(String.valueOf(activeCount));
+
+        layoutEmptyState.setVisibility(activeCount == 0 ? View.VISIBLE : View.GONE);
+        rvPanicAlerts.setVisibility(activeCount > 0 ? View.VISIBLE : View.GONE);
+    }
+}
+
+
+

--- a/mobileapp/app/src/main/java/com/example/mobileapp/features/admin/services/AdminPanicService.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/features/admin/services/AdminPanicService.java
@@ -1,0 +1,68 @@
+package com.example.mobileapp.features.admin.services;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import com.example.mobileapp.core.network.ApiClient;
+import com.example.mobileapp.features.shared.api.AdminApi;
+import com.example.mobileapp.features.shared.api.dto.PanicNotificationDto;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class AdminPanicService {
+    private final MutableLiveData<List<PanicNotificationDto>> _panics = new MutableLiveData<>();
+    public LiveData<List<PanicNotificationDto>> panics() { return _panics; }
+
+    private final AdminApi api;
+    private final SharedPreferences prefs;
+
+    public AdminPanicService(Context context) {
+        prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE);
+        api = ApiClient.get().create(AdminApi.class);
+    }
+
+    public void fetchPanics() {
+        String token = prefs.getString("jwt", null);
+        if (token == null) return;
+
+        api.getPanicNotifications("Bearer " + token)
+                .enqueue(new Callback<List<PanicNotificationDto>>() {
+                    @Override
+                    public void onResponse(Call<List<PanicNotificationDto>> call, Response<List<PanicNotificationDto>> response) {
+                        if (response.isSuccessful()) {
+                            _panics.setValue(response.body());
+                        }
+                    }
+
+                    @Override public void onFailure(Call<List<PanicNotificationDto>> call, Throwable t) {}
+                });
+    }
+
+    public void resolvePanic(Integer rideId) {
+        String token = prefs.getString("jwt", null);
+        api.resolvePanic("Bearer " + token, rideId)
+                .enqueue(new Callback<>() {
+                    @Override
+                    public void onResponse(@NonNull Call<Void> call, @NonNull Response<Void> response) {
+                        if (response.isSuccessful()) {
+                            fetchPanics();
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(@NonNull retrofit2.Call<Void> call,
+                                          @NonNull Throwable t) {
+                    }
+                });
+    }
+
+}
+

--- a/mobileapp/app/src/main/java/com/example/mobileapp/features/shared/api/AdminApi.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/features/shared/api/AdminApi.java
@@ -2,12 +2,14 @@ package com.example.mobileapp.features.shared.api;
 
 import com.example.mobileapp.features.shared.api.dto.DriverListItemDto;
 import com.example.mobileapp.features.shared.api.dto.DriverRideDto;
+import com.example.mobileapp.features.shared.api.dto.PanicNotificationDto;
 
 import java.util.List;
 
 import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
+import retrofit2.http.PUT;
 import retrofit2.http.Path;
 
 public interface AdminApi {
@@ -21,5 +23,14 @@ public interface AdminApi {
     Call<List<DriverRideDto>> getDriverRides(
             @Header("Authorization") String authHeader,
             @Path("driverEmail") String driverEmail
+    );
+    @GET("api/admin/panic-notifications")
+    Call<List<PanicNotificationDto>> getPanicNotifications(
+            @Header("Authorization") String authHeader
+    );
+    @PUT("api/admin/panic-notifications/{rideId}/resolve")
+    Call<Void> resolvePanic(
+            @Header("Authorization") String bearerToken,
+            @Path("rideId") Integer rideId
     );
 }

--- a/mobileapp/app/src/main/java/com/example/mobileapp/features/shared/api/RidesApi.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/features/shared/api/RidesApi.java
@@ -4,12 +4,12 @@ import com.example.mobileapp.features.shared.api.dto.CreateRideRequestDto;
 import com.example.mobileapp.features.shared.api.dto.DriverRideDto;
 import com.example.mobileapp.features.shared.api.dto.PassengerRideDto;
 import com.example.mobileapp.features.shared.api.dto.PriceEstimateResponse;
-import com.example.mobileapp.features.shared.api.dto.RideDto;
-import com.example.mobileapp.features.shared.api.dto.RideHistoryDto;
 import com.example.mobileapp.features.shared.api.dto.RideDetailDto;
+import com.example.mobileapp.features.shared.api.dto.RideDto;
 import com.example.mobileapp.features.shared.api.dto.RideEstimateRequest;
 import com.example.mobileapp.features.shared.api.dto.RideHistoryResponseDto;
 import com.example.mobileapp.features.shared.api.dto.RideInconsistencyRequestDto;
+import com.example.mobileapp.features.shared.api.dto.RidePanicDto;
 
 import java.util.List;
 
@@ -83,5 +83,12 @@ public interface RidesApi {
     Call<Void> arrivedAtPickup(
             @Header("Authorization") String bearerToken,
             @Path("id") int rideId
+    );
+
+    @POST("api/rides/{id}/panic")
+    Call<Void> panic(
+            @Header("Authorization") String bearerToken,
+            @Path("id") int rideId,
+            @Body RidePanicDto request
     );
 }

--- a/mobileapp/app/src/main/java/com/example/mobileapp/features/shared/api/dto/DriverRideDto.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/features/shared/api/dto/DriverRideDto.java
@@ -32,4 +32,7 @@ public class DriverRideDto {
     public String vehicleLicensePlate;
 
     public String arrivedAtPickupTime;
+
+    public Boolean getPanicTriggered() { return panicActivated; }
+    public void setPanicTriggered(Boolean panicTriggered) { this.panicActivated = panicTriggered; }
 }

--- a/mobileapp/app/src/main/java/com/example/mobileapp/features/shared/api/dto/PanicNotificationDto.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/features/shared/api/dto/PanicNotificationDto.java
@@ -1,0 +1,62 @@
+package com.example.mobileapp.features.shared.api.dto;
+
+import com.example.mobileapp.features.shared.models.enums.UserRole;
+
+import java.time.LocalDateTime;
+
+public class PanicNotificationDto {
+    private Integer id;
+    private Integer rideId;
+    private String activatedBy;
+    private Integer driverId;
+    private LocalDateTime timestamp;
+    private UserRole userType;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getRideId() {
+        return rideId;
+    }
+
+    public void setRideId(Integer rideId) {
+        this.rideId = rideId;
+    }
+
+    public String getActivatedBy() {
+        return activatedBy;
+    }
+
+    public void setActivatedBy(String activatedBy) {
+        this.activatedBy = activatedBy;
+    }
+
+    public Integer getDriverId() {
+        return driverId;
+    }
+
+    public void setDriverId(Integer driverId) {
+        this.driverId = driverId;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public UserRole getUserType() {
+        return userType;
+    }
+
+    public void setUserType(UserRole userType) {
+        this.userType = userType;
+    }
+}

--- a/mobileapp/app/src/main/java/com/example/mobileapp/features/shared/api/dto/PassengerRideDto.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/features/shared/api/dto/PassengerRideDto.java
@@ -9,9 +9,12 @@ public class PassengerRideDto {
     public String vehicleModel;
     public String vehicleLicensePlate;
     public String driverEmail;
+    public boolean panicActivated;
     public LocationDto startLocation;
     public LocationDto endLocation;
     public List<LocationDto> waypoints;
     public List<PassengerDto> passengers;
     public String scheduledTime;
+    public Boolean getPanicTriggered() { return panicActivated; }
+    public void setPanicTriggered(Boolean panicTriggered) { this.panicActivated = panicTriggered; }
 }

--- a/mobileapp/app/src/main/java/com/example/mobileapp/features/shared/api/dto/RidePanicDto.java
+++ b/mobileapp/app/src/main/java/com/example/mobileapp/features/shared/api/dto/RidePanicDto.java
@@ -1,0 +1,8 @@
+package com.example.mobileapp.features.shared.api.dto;
+
+public class RidePanicDto {
+    public Integer userId;
+    public RidePanicDto(Integer userId) {
+        this.userId = userId;
+    }
+}

--- a/mobileapp/app/src/main/res/drawable/bg_btn_resolve.xml
+++ b/mobileapp/app/src/main/res/drawable/bg_btn_resolve.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke
+        android:width="2dp"
+        android:color="#DC2626" />
+    <corners android:radius="6dp" />
+    <solid android:color="#FFFFFF" />
+</shape>

--- a/mobileapp/app/src/main/res/drawable/bg_panic_badge.xml
+++ b/mobileapp/app/src/main/res/drawable/bg_panic_badge.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FEE2E2" />
+    <corners android:radius="4dp" />
+</shape>

--- a/mobileapp/app/src/main/res/drawable/circle_red_background.xml
+++ b/mobileapp/app/src/main/res/drawable/circle_red_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#DC2626" />
+</shape>

--- a/mobileapp/app/src/main/res/drawable/ic_alert.xml
+++ b/mobileapp/app/src/main/res/drawable/ic_alert.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,2C12.5523,2 13,2.4477 13,3L13,13C13,13.5523 12.5523,14 12,14C11.4477,14 11,13.5523 11,13L11,3C11,2.4477 11.4477,2 12,2Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,17C12.8284,17 13.5,17.6716 13.5,18.5C13.5,19.3284 12.8284,20 12,20C11.1716,20 10.5,19.3284 10.5,18.5C10.5,17.6716 11.1716,17 12,17Z" />
+</vector>

--- a/mobileapp/app/src/main/res/layout/fragment_admin_panics.xml
+++ b/mobileapp/app/src/main/res/layout/fragment_admin_panics.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#F5F5F5"
+    android:padding="16dp">
+
+    <!-- Header Section -->
+    <TextView
+        android:id="@+id/tvPanicAlerts"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Panic Alerts"
+        android:textColor="#000000"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tvActiveCount"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="3 active"
+        android:textColor="#666666"
+        android:textSize="14sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvPanicAlerts" />
+
+    <TextView
+        android:id="@+id/tvAlertCount"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="3"
+        android:textColor="#DC2626"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!-- RecyclerView for alerts -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvPanicAlerts"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="24dp"
+        android:clipToPadding="false"
+        android:overScrollMode="never"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvActiveCount"
+        tools:listitem="@layout/item_admin_panic" />
+
+    <!-- Empty State -->
+    <LinearLayout
+        android:id="@+id/layoutEmptyState"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvActiveCount"
+        tools:visibility="gone">
+
+        <ImageView
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            android:alpha="0.3"
+            android:src="@drawable/ic_alert"
+            app:tint="#666666" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="No active panic alerts"
+            android:textColor="#666666"
+            android:textSize="16sp" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/mobileapp/app/src/main/res/layout/fragment_current_ride.xml
+++ b/mobileapp/app/src/main/res/layout/fragment_current_ride.xml
@@ -197,6 +197,20 @@
                     android:background="@drawable/bg_btn_dark"
                     android:layout_marginBottom="12dp"/>
 
+                <TextView
+                    android:id="@+id/btnPanic"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:gravity="center"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:text="@string/panic"
+                    android:textStyle="bold"
+                    android:textSize="13sp"
+                    android:textColor="#FFFFFF"
+                    android:background="@drawable/bg_btn_red"
+                    android:layout_marginBottom="12dp"/>
+
                 <!-- Report driver inconsistency -->
                 <androidx.cardview.widget.CardView
                     android:id="@+id/cardReport"

--- a/mobileapp/app/src/main/res/layout/fragment_driver_dashboard.xml
+++ b/mobileapp/app/src/main/res/layout/fragment_driver_dashboard.xml
@@ -295,6 +295,7 @@
                     android:layout_marginEnd="10dp"/>
 
                 <TextView
+                    android:id="@+id/btnPanic"
                     android:layout_width="88dp"
                     android:layout_height="40dp"
                     android:gravity="center"

--- a/mobileapp/app/src/main/res/layout/item_admin_panic.xml
+++ b/mobileapp/app/src/main/res/layout/item_admin_panic.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="16dp"
+    app:cardBackgroundColor="#FEF2F2"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="0dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <!-- Alert Icon -->
+        <ImageView
+            android:id="@+id/ivAlertIcon"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="@drawable/circle_red_background"
+            android:padding="12dp"
+            android:src="@drawable/ic_alert"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="#FFFFFF" />
+
+        <!-- Ride Number -->
+        <TextView
+            android:id="@+id/tvRideNumber"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="8dp"
+            android:textColor="#000000"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toStartOf="@id/tvActive"
+            app:layout_constraintStart_toEndOf="@id/ivAlertIcon"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Ride #32" />
+
+        <!-- User Email -->
+        <TextView
+            android:id="@+id/tvUserEmail"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="8dp"
+            android:textColor="#666666"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toStartOf="@id/tvActive"
+            app:layout_constraintStart_toEndOf="@id/ivAlertIcon"
+            app:layout_constraintTop_toBottomOf="@id/tvRideNumber"
+            tools:text="User Email: d58@uberplus.com" />
+
+        <!-- Active Badge -->
+        <TextView
+            android:id="@+id/tvActive"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:background="@drawable/bg_panic_badge"
+            android:paddingStart="12dp"
+            android:paddingTop="4dp"
+            android:paddingEnd="12dp"
+            android:paddingBottom="4dp"
+            android:text="ACTIVE"
+            android:textColor="#DC2626"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toStartOf="@id/btnResolve"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <!-- Resolve Button -->
+        <Button
+            android:id="@+id/btnResolve"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:background="@drawable/bg_btn_resolve"
+            tools:backgroundTint="@null"
+            android:backgroundTint="@null"
+            app:backgroundTint="@null"
+            android:paddingStart="20dp"
+            android:paddingEnd="20dp"
+            android:text="Resolve"
+            android:textAllCaps="false"
+            android:textColor="#DC2626"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <!-- Time -->
+        <TextView
+            android:id="@+id/tvTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:textColor="#666666"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="@id/tvRideNumber"
+            app:layout_constraintTop_toBottomOf="@id/tvUserEmail"
+            tools:text="Time:  2/10/26, 8:27 PM" />
+
+        <!-- Type Label -->
+        <TextView
+            android:id="@+id/tvTypeLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Type:  "
+            android:textColor="#666666"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toStartOf="@id/tvType"
+            app:layout_constraintTop_toBottomOf="@id/tvUserEmail" />
+
+        <!-- Type Value -->
+        <TextView
+            android:id="@+id/tvType"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="#3B82F6"
+            android:textSize="14sp"
+            app:layout_constraintBaseline_toBaselineOf="@id/tvTypeLabel"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="Driver" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.cardview.widget.CardView>

--- a/mobileapp/gradle/libs.versions.toml
+++ b/mobileapp/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ recyclerview = "1.4.0"
 glide = "5.0.0-rc01"
 compiler = "5.0.0-rc01"
 materialVersion = "1.13.0"
+swiperefreshlayout = "1.2.0"
 
 [libraries]
 cardview = { module = "androidx.cardview:cardview", version.ref = "cardview" }
@@ -28,6 +29,7 @@ recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version
 glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
 compiler = { group = "com.github.bumptech.glide", name = "compiler", version.ref = "compiler" }
 google-material = { group = "com.google.android.material", name = "material", version.ref = "materialVersion" }
+swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version.ref = "swiperefreshlayout" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Implements a panic/alert workflow across the app: drivers and passengers can trigger a panic for a ride, and admins can view and resolve active panic notifications.

Key changes:
- New admin panic UI: AdminPanicsFragment, AdminPanicAdapter, item_admin_panic layout, fragment_admin_panics layout and supporting drawables (badge, alert icon, resolve button background).
- Admin service/API: AdminPanicService + AdminApi endpoints to list and resolve panic notifications.
- Rides API: added POST /api/rides/{id}/panic and RidePanicDto to send panic requests.
- DTOs: PanicNotificationDto added; PassengerRideDto and DriverRideDto expose panicTriggered accessor.
- Driver & Passenger clients: added panic buttons and handling in DriverDashboardFragment and CurrentRideFragment (UI state, confirmation dialogs, network calls, and feedback). Added resolving refresh behavior.
- Navigation: AdminMainActivity opens AdminPanicsFragment from navigation drawer.
- Auth: AuthApi activate endpoint + AuthActivity handles account activation links and shows LoginFragment; LoginFragment now stores userId in SharedPreferences. Activation still doesn't work on mobile.

Closes #85 